### PR TITLE
Expand absolute path search to Windows

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,7 +10,7 @@ else
 	against=$(git hash-object -t tree /dev/null)
 fi
 
-if git diff --cached $against | grep -e '/Users' -e '/home' >/dev/null 2>&1
+if git diff --cached $against | grep -e '/Users' -e '/home' -e 'C:/' >/dev/null 2>&1
 then
     cat <<\EOF
 Error: Attempt to add reference to absolute path.


### PR DESCRIPTION
Previously this commit hook was only checking for the presence of paths on MacOS and other Unix flavored systems.  This expands the check to search for the presence of a Windows "C:\" (though the slash is reversed to conform to the syntax of Kicad).